### PR TITLE
Added nx and message context

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
+  "useNx": true,
   "version": "0.0.0"
 }

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,35 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test:ts"
+        ]
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": [
+        "^build", "lint", "test:ts"
+      ],
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
+    },
+    "lint": {
+      "dependsOn": [
+        "^lint"
+      ]
+    },
+    "test:ts": {
+      "dependsOn": [
+        "^test:ts"
+      ]
+    }
+  },
+  "defaultBase": "master"
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "lerna": "^6.5.1"
+    "lerna": "^6.5.1",
+    "nx": "15.7.2"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "description": "The BotComet Authentication implementation",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src --ext .ts",
+    "test:ts": "tsc --noEmit"
   },
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/comet/package.json
+++ b/packages/comet/package.json
@@ -6,7 +6,9 @@
   "description": "BotComet's Comet implementation",
   "main": "index.js",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src --ext .ts",
+    "test:ts": "tsc --noEmit"
   },
   "keywords": [],
   "author": "The BotComet Team",

--- a/packages/comet/src/Comet.ts
+++ b/packages/comet/src/Comet.ts
@@ -1,13 +1,18 @@
 import { Client } from "discord.js";
 import WebSocket from "ws";
 
-import { DualSet, Message, next_obfuscated_id } from "@botcomet/protocol";
+import {
+  DualSet, Message,
+  Context, ContextCache,
+  next_obfuscated_id
+} from "@botcomet/protocol";
 import { Padlock } from "@botcomet/auth";
 
 const STATION_ADDRESS = "ws://localhost:8080";
 
 class Comet {
   private client: Client;
+  private client_id = "";
   private station_conn: WebSocket | null = null;
 
   // Sets of obfuscated IDs. Only the comet knows what
@@ -16,6 +21,8 @@ class Comet {
   private station_channels: DualSet<string, string> = new DualSet();
   private station_users: DualSet<string, string> = new DualSet();
   private station_messages: DualSet<string, string> = new DualSet();
+
+  private message_context: ContextCache = new Map();
 
   // Padlocks used to verify plugins.
   private padlocks: Map<string, Padlock> = new Map();
@@ -40,7 +47,7 @@ class Comet {
       this.sendStationMessage({
         type: "message_create",
         dst: "STATION",
-        src: "COMET",
+        src: this.client_id,
         context: "CONTEXT",
         data: {
           id: obfuscated_id,
@@ -68,18 +75,42 @@ class Comet {
       this.evaluateStationMessage(message);
     });
 
+    const context_id = next_obfuscated_id();
+    this.message_context.set(context_id, {
+      type: "comet_connect",
+      data: {}
+    });
+
     this.sendStationMessage({
       type: "comet_connect",
       dst: "STATION",
-      src: "COMET",
-      context: "CONTEXT",
+      src: "CONNECTION",
+      context: context_id,
       data: {}
     });
   }
 
   // Evaluates a message from the station.
   private evaluateStationMessage(message: Message) {
-    console.log(message);
+    switch (message.type) {
+
+    case "comet_connect_response": {
+      if (!this.message_context.has(message.context)) {
+        console.error("Comet connect response context not found!");
+        return;
+      }
+
+      const context = this.message_context.get(message.context)!;
+      if (context.type !== "comet_connect") {
+        console.error("Comet connect response context type mismatch!");
+        return;
+      }
+
+      this.message_context.delete(message.context);
+      this.client_id = message.dst;
+    } break;
+
+    }
   }
 
   // Sends a message to the station.

--- a/packages/comet/src/Comet.ts
+++ b/packages/comet/src/Comet.ts
@@ -39,7 +39,9 @@ class Comet {
       this.station_messages.Set(obfuscated_id, message.id);
       this.sendStationMessage({
         type: "message_create",
-        destination: "STATION",
+        dst: "STATION",
+        src: "COMET",
+        context: "CONTEXT",
         data: {
           id: obfuscated_id,
           content: message.content
@@ -68,7 +70,9 @@ class Comet {
 
     this.sendStationMessage({
       type: "comet_connect",
-      destination: "STATION",
+      dst: "STATION",
+      src: "COMET",
+      context: "CONTEXT",
       data: {}
     });
   }

--- a/packages/comet/src/index.ts
+++ b/packages/comet/src/index.ts
@@ -4,4 +4,4 @@ import { config } from "dotenv";
 config();
 
 const comet = new Comet();
-comet.Start(process.env.TOKEN!);
+comet.start(process.env.TOKEN!);

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -4,7 +4,9 @@
   "description": "The BotComet Plugin implementation",
   "type": "module",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src --ext .ts",
+    "test:ts": "tsc --noEmit"
   },
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/plugin/src/Plugin.ts
+++ b/packages/plugin/src/Plugin.ts
@@ -22,7 +22,9 @@ class Plugin {
   private onOpen() {
     this.sendStationMessage({
       type: "plugin_connect",
-      destination: "STATION",
+      dst: "STATION",
+      src: "PLUGIN",
+      context: "CONTEXT",
       data: {}
     });
   }
@@ -41,7 +43,9 @@ class Plugin {
 
       this.sendStationMessage({
         type: "plugin_verify_response",
-        destination: "STATION",
+        dst: "STATION",
+        src: "PLUGIN",
+        context: "CONTEXT",
         data: { challenge }
       });
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -6,7 +6,9 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src --ext .ts",
+    "test:ts": "tsc --noEmit"
   },
   "author": "The BotComet Team",
   "license": "MIT",

--- a/packages/protocol/src/Context.ts
+++ b/packages/protocol/src/Context.ts
@@ -1,0 +1,9 @@
+
+interface Context {
+  type: string;
+  data: any;
+}
+
+type ContextCache = Map<string, Context>;
+
+export type { Context, ContextCache };

--- a/packages/protocol/src/Message.ts
+++ b/packages/protocol/src/Message.ts
@@ -1,6 +1,7 @@
 
 type MessageType = 
   "comet_connect" | "plugin_connect" |
+  "comet_connect_response" | "plugin_connect_response" |
   "message_create" | "plugin_verify" | "plugin_verify_response";
 
 interface Message {

--- a/packages/protocol/src/Message.ts
+++ b/packages/protocol/src/Message.ts
@@ -1,6 +1,7 @@
 
 type MessageType = 
-  "comet_connect" | "plugin_connect";
+  "comet_connect" | "plugin_connect" |
+  "message_create" | "plugin_verify" | "plugin_verify_response";
 
 interface Message {
   type: MessageType;

--- a/packages/protocol/src/Message.ts
+++ b/packages/protocol/src/Message.ts
@@ -5,7 +5,9 @@ type MessageType =
 
 interface Message {
   type: MessageType;
-  destination: string;
+  src: string;
+  dst: string;
+  context: string;
   data: any;
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,6 @@
 export { default as DualSet } from "./DualSet.js";
 export type { Message } from "./Message.js";
+export type { Context, ContextCache } from "./Context.js";
 
 function next_obfuscated_id(): string {
   return Math.random().toString(36).substring(2);

--- a/packages/station/package.json
+++ b/packages/station/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.1",
   "description": "The BotComet Station implementation",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src --ext .ts",
+    "test:ts": "tsc --noEmit"
   },
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/station/src/Station.ts
+++ b/packages/station/src/Station.ts
@@ -36,12 +36,31 @@ class Station {
   private onMessage(message: string, ws: WebSocket) {
     const msg: Message = JSON.parse(message);
     switch (msg.type) {
-    case "comet_connect":
-      this.comets.Set(ws, next_obfuscated_id());
-      break;
-    case "plugin_connect":
-      this.plugins.Set(ws, next_obfuscated_id());
-      break;
+
+    case "comet_connect": {
+      const comet_id = next_obfuscated_id();
+      this.comets.Set(ws, comet_id);
+      ws.send(JSON.stringify({
+        type: "comet_connect_response",
+        dst: comet_id,
+        src: "STATION",
+        context: msg.context,
+        data: {}
+      }));
+    } break;
+
+    case "plugin_connect": {
+      const plugin_id = next_obfuscated_id();
+      this.plugins.Set(ws, plugin_id);
+      ws.send(JSON.stringify({
+        type: "plugin_connect_response",
+        dst: plugin_id,
+        src: "STATION",
+        context: msg.context,
+        data: {}
+      }));
+    } break;
+
     default:
       // Error
       break;


### PR DESCRIPTION
* Added nx, with support for building, linting, and type checking.
* Added message context field. The Message type is now very different, with `src` and `dst` fields along with `context`.
* Added ContextCache type, a property of Comets and Plugins
* Added Comet and Plugin address requesting from Station

Closes #3 
Closes #6 